### PR TITLE
ignore broken links when calculating directory size

### DIFF
--- a/main/files.py
+++ b/main/files.py
@@ -36,7 +36,13 @@ class DirectoryFiles:
         for dirpath, _, filenames in os.walk(start_path):
             for f in filenames:
                 fp = os.path.join(dirpath, f)
-                total_size += os.path.getsize(fp)
+                try:
+                    total_size += os.path.getsize(fp)
+                except FileNotFoundError:
+                    # Could be a broken symlink or some other weirdness.
+                    # Trap the error here so that the directory can continue
+                    # to be successfully processed.
+                    pass
         return total_size
 
     @classmethod

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -71,6 +71,14 @@ class TestDirectoryFiles(unittest.TestCase):
         except Exception as e:
             self.fail(f'Exception occured when tried to get_size for an empty folder {e}')
 
+    def test_get_dir_size_broken_symlink(self):
+        os.symlink(
+            '/this/path/could/not/possibly/exist/like/evar',
+            os.path.join(self.tmpd.name, 'broken-link'),
+        )
+        size = DirectoryFiles().get_dir_size(self.tmpd.name)
+        self.assertEqual(0, size)
+
     def test_sort_data(self):
         try:
             data = [


### PR DESCRIPTION
I noticed that vizex was mysteriously skipping over some of my subdirectories and decided to investigate. I found that broken symlinks were causing the entire directory to be skipped entirely when calculating the directory's total size.

I modified the code to ignore broken links, i.e. they do not contribute to the total size at all. This is similar to the behavior of df, and is more predictable for the user. Hope you find this patch useful.

Cool project, by the way!